### PR TITLE
Remove hard dependency between order of results and observations

### DIFF
--- a/app/reports/spree/report.rb
+++ b/app/reports/spree/report.rb
@@ -65,7 +65,7 @@ module Spree
 
       query = query.order(active_record_sort) if sortable_attribute.present?
       query_sql = query.to_sql
-      r = ActiveRecord::Base.connection.exec_query(query_sql)
+      ActiveRecord::Base.connection.exec_query(query_sql)
     end
 
     def set_sortable_attributes(options, default_sortable_attribute)

--- a/app/reports/spree/report/date_slicer.rb
+++ b/app/reports/spree/report/date_slicer.rb
@@ -15,7 +15,7 @@ module Spree::Report::DateSlicer
   def self.slice_hours_into(start_date, end_date, klass)
     current_date = start_date
     slices = []
-    while current_date < end_date
+    while current_date <= end_date
       slices << (0..23).collect do |hour|
         obj = klass.new
         obj.date = current_date
@@ -30,7 +30,7 @@ module Spree::Report::DateSlicer
   def self.slice_days_into(start_date, end_date, klass)
     current_date = start_date
     slices = []
-    while current_date < end_date
+    while current_date <= end_date
       obj = klass.new
       obj.date = current_date
       slices << obj
@@ -42,7 +42,7 @@ module Spree::Report::DateSlicer
   def self.slice_months_into(start_date, end_date, klass)
     current_date = start_date
     slices = []
-    while current_date < end_date
+    while current_date <= end_date
       obj = klass.new
       obj.date = current_date
       slices << obj

--- a/app/reports/spree/report/timed_result.rb
+++ b/app/reports/spree/report/timed_result.rb
@@ -13,21 +13,9 @@ module Spree
       end
 
       def populate_observations
-        observation_iter = @observations.each
-        current_observation = @observations.present? ? observation_iter.next : nil
         @results.each do |result|
-          if current_observation.present?
-            begin
-              until current_observation.describes? result, time_scale
-                current_observation = observation_iter.next
-              end
-
-              current_observation.populate(result)
-              current_observation = observation_iter.next
-            rescue StopIteration
-              break
-            end
-          end
+          matching_observation = @observations.find { |observation| observation.describes? result, time_scale }
+          matching_observation.populate result
         end
       end
 

--- a/app/reports/spree/shipping_cost_report.rb
+++ b/app/reports/spree/shipping_cost_report.rb
@@ -26,7 +26,7 @@ module Spree
         observation_fields [:name, :shipping_charge, :revenue, :shipping_cost_percentage]
 
         def describes?(result, time_scale)
-          (name = result['name']) && super
+          (name == result['name']) && super
         end
 
         def shipping_cost_percentage
@@ -50,7 +50,7 @@ module Spree
           'shipping_charge',
           'shipping_method_id',
           'name'
-        )
+        ).order('shipping_method_id', *time_scale_columns)
     end
 
     private def order_with_shipments


### PR DESCRIPTION
Some reports may have results being interleaved by date instead of
categorywise by date, which causes current populator to skip them.

Fixing it by replacing with a find and fill approach.